### PR TITLE
Add tests for Herrenberg

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Run search queries against a geocoder that supports [geocodejson spec](https://github.com/geocoders/geocodejson-spec).
 
-## Intalling
+## Installing
 
 - create a python >= 3.4 [virtualenv](http://docs.python-guide.org/en/latest/dev/virtualenvs/) environment
 - `git clone https://github.com/geocoders/geocoder-tester && cd geocoder-tester`
@@ -38,7 +38,7 @@ How can I stop at first failing test?
 
 Can I change the api URL I'm testing against?
 
-    py.test --api-url http://photon.komoot.de/api/
+    py.test --api-url http://photon.komoot.de/api/ --api-type photon
 
 Can I limit the number of tests to be run (even if my filter select thousands
 of tests) ?
@@ -87,17 +87,22 @@ They are normal python tests. Just note that you have two utils in `base.py`:
 
 ### CSV
 
-One column is mandatory: `query`, where you store the query you make.
+```csv
+comment;query;lon;lat;expected_housenumber;expected_street;expected_city;lang;limit
+```
+
+One column is mandatory: `query`, where you store the query you make.  
 Then you can add as many `expected_xxx` columns you want, according to what
 you want to test. For example, to test the name in the result, you will store
 the expected value in the column `expected_name`; for an `osm_id` it will be
-`expected_osm_id`, and so on. Note on `expected_coordinate` format: it should be
+`expected_osm_id`, and so on.  
+Note on `expected_coordinate` format: it should be
 of the form `lat,lon,tolerated deviation in meters`, e.g. `51.0,10.3,700`.
 
 Optional columns:
 * `limit`: decide how many results you want to look at for finding your result
-(defaul: 1)
-* `lat`, `lon`: if you want to add a center for the search
+(default: 1)
+* `lat`, `lon`: if you want to add a center for the search (location bias)
 * `comment`: if you want to take control of the ouput of the test in the
 command line
 * `lang`: language

--- a/conftest.py
+++ b/conftest.py
@@ -133,7 +133,7 @@ class CSVFile(pytest.File):
 
     def collect(self):
         with self.fspath.open(encoding="utf-8") as f:
-            dialect = csv.Sniffer().sniff(f.read(1024))
+            dialect = csv.Sniffer().sniff(f.readline())
             f.seek(0)
             reader = csv.DictReader(f, dialect=dialect)
             for row in reader:

--- a/geocoder_tester/world/germany/herrenberg/test_custom_feedback.csv
+++ b/geocoder_tester/world/germany/herrenberg/test_custom_feedback.csv
@@ -3,7 +3,7 @@ test house number and street;Derendinger Stra 104;8.86487934;48.5964194;104;Dere
 test house number and street;Derendin Stra 104;8.86487934;48.5964194;104;Derendinger Straße;Tübingen;;de;
 test house number and street;Derendinger Stra 62;8.86487934;48.5964194;62;Derendinger Straße;Tübingen;;de;
 test house number and street;Derendinger Stra 28;8.86487934;48.5964194;28;Derendinger Straße;Tübingen;;de;
-test house number and street;Derendinger Stra 20;8.86487934;48.5964194;20;Derendinger Straße;Tübingen;;de;
+test house number and street;Derendinger Stra 22;8.86487934;48.5964194;22;Derendinger Straße;Tübingen;;de;
 test house number and street;Schelling Straße 37;8.86487934;48.5964194;37;Schellingstraße;Tübingen;;de;5
 test house number and street;SchellingStra 37;8.86487934;48.5964194;37;Schellingstraße;Tübingen;;de;
 test house number and street;Moltke straße 21;8.86487934;48.5964194;21;Moltkestraße;Gärtringen;;de;
@@ -17,4 +17,6 @@ reported;E-bikes station, Herrenberg Bahnhof;8.86487934;48.5964194;;;Vaihingen a
 reported;VHS;8.86487934;48.5964194;;;Herrenberg;48.5940213,8.8735124,800;de;
 reported;Stadtarchiv;8.86487934;48.5964194;;;Herrenberg;48.592641,8.87408,800;de;
 reported;Stadtbibliothek;8.86487934;48.5964194;;;Mötzingen;48.533602,8.7748135,800;de;
-reported;Krankenhaus Herrenberg;8.86487934;48.5964194;;;Herrenberg;48.5920188,8.8769826,800;de;
+reported (synonyms);Krankenhaus Herrenberg;8.86487934;48.5964194;;;Herrenberg;48.5920188,8.8769826,800;de;
+reported (synonyms);Klinikum Herrenberg;8.86487934;48.5964194;;;Herrenberg;48.5920188,8.8769826,800;de;
+

--- a/geocoder_tester/world/germany/herrenberg/test_custom_feedback.csv
+++ b/geocoder_tester/world/germany/herrenberg/test_custom_feedback.csv
@@ -1,0 +1,10 @@
+comment;query;lon;lat;expected_housenumber;expected_street;expected_city;lang;limit
+test house number and street;Derendinger Stra 104;8.86487934;48.5964194;104;Derendinger Straße;Tübingen;de;
+test house number and street;Derendin Stra 104;8.86487934;48.5964194;104;Derendinger Straße;Tübingen;de;
+test house number and street;Derendinger Stra 62;8.86487934;48.5964194;62;Derendinger Straße;Tübingen;de;
+test house number and street;Derendinger Stra 28;8.86487934;48.5964194;28;Derendinger Straße;Tübingen;de;
+test house number and street;Derendinger Stra 20;8.86487934;48.5964194;20;Derendinger Straße;Tübingen;de;
+test house number and street;Schelling Straße 37;8.86487934;48.5964194;37;Schellingstraße;Tübingen;de;5
+test house number and street;SchellingStra 37;8.86487934;48.5964194;37;Schellingstraße;Tübingen;de;
+test house number and street;Moltke straße 21;8.86487934;48.5964194;21;Moltkestraße;Gärtringen;de;
+test house number and street;62b Grabenstraße Rohrau;8.86487934;48.5964194;62b;Grabenstraße;Gärtringen;de;3

--- a/geocoder_tester/world/germany/herrenberg/test_custom_feedback.csv
+++ b/geocoder_tester/world/germany/herrenberg/test_custom_feedback.csv
@@ -1,10 +1,20 @@
-comment;query;lon;lat;expected_housenumber;expected_street;expected_city;lang;limit
-test house number and street;Derendinger Stra 104;8.86487934;48.5964194;104;Derendinger Straße;Tübingen;de;
-test house number and street;Derendin Stra 104;8.86487934;48.5964194;104;Derendinger Straße;Tübingen;de;
-test house number and street;Derendinger Stra 62;8.86487934;48.5964194;62;Derendinger Straße;Tübingen;de;
-test house number and street;Derendinger Stra 28;8.86487934;48.5964194;28;Derendinger Straße;Tübingen;de;
-test house number and street;Derendinger Stra 20;8.86487934;48.5964194;20;Derendinger Straße;Tübingen;de;
-test house number and street;Schelling Straße 37;8.86487934;48.5964194;37;Schellingstraße;Tübingen;de;5
-test house number and street;SchellingStra 37;8.86487934;48.5964194;37;Schellingstraße;Tübingen;de;
-test house number and street;Moltke straße 21;8.86487934;48.5964194;21;Moltkestraße;Gärtringen;de;
-test house number and street;62b Grabenstraße Rohrau;8.86487934;48.5964194;62b;Grabenstraße;Gärtringen;de;3
+comment;query;lon;lat;expected_housenumber;expected_street;expected_city;expected_coordinate;lang;limit
+test house number and street;Derendinger Stra 104;8.86487934;48.5964194;104;Derendinger Straße;Tübingen;;de;
+test house number and street;Derendin Stra 104;8.86487934;48.5964194;104;Derendinger Straße;Tübingen;;de;
+test house number and street;Derendinger Stra 62;8.86487934;48.5964194;62;Derendinger Straße;Tübingen;;de;
+test house number and street;Derendinger Stra 28;8.86487934;48.5964194;28;Derendinger Straße;Tübingen;;de;
+test house number and street;Derendinger Stra 20;8.86487934;48.5964194;20;Derendinger Straße;Tübingen;;de;
+test house number and street;Schelling Straße 37;8.86487934;48.5964194;37;Schellingstraße;Tübingen;;de;5
+test house number and street;SchellingStra 37;8.86487934;48.5964194;37;Schellingstraße;Tübingen;;de;
+test house number and street;Moltke straße 21;8.86487934;48.5964194;21;Moltkestraße;Gärtringen;;de;
+test house number and street;62b Grabenstraße Rohrau;8.86487934;48.5964194;62b;Grabenstraße;Gärtringen;;de;3
+reported;Pulverturm Herrenberg, Herrenberg;8.86487934;48.5964194;;;Herrenberg;48.595557,8.8674715,800;de;2
+reported;Schlossbergturm Herrenberg, Herrenberg;8.86487934;48.5964194;;;Herrenberg;48.59752855,8.873141062390543,800;de;
+reported;Herrenberger Straße, Herrenberg;8.86487934;48.5964194;;;Nufringen;48.614423,8.8814198,800;de;
+reported;Stuttgart hauptbahnhof, Stuttgart;8.86487934;48.5964194;;;Stuttgart;48.7856099,9.1833959,800;de;
+reported;Böblingen Bahnhof, Böblingen;8.86487934;48.5964194;;;Herrenberg;48.593861700000005,8.86307270000001,800;de;
+reported;E-bikes station, Herrenberg Bahnhof;8.86487934;48.5964194;;;Vaihingen an der Enz;48.947360950000004,8.957937857930657,800;de;
+reported;VHS;8.86487934;48.5964194;;;Herrenberg;48.5940213,8.8735124,800;de;
+reported;Stadtarchiv;8.86487934;48.5964194;;;Herrenberg;48.592641,8.87408,800;de;
+reported;Stadtbibliothek;8.86487934;48.5964194;;;Mötzingen;48.533602,8.7748135,800;de;
+reported;Krankenhaus Herrenberg;8.86487934;48.5964194;;;Herrenberg;48.5920188,8.8769826,800;de;

--- a/geocoder_tester/world/germany/herrenberg/test_custom_feedback.csv
+++ b/geocoder_tester/world/germany/herrenberg/test_custom_feedback.csv
@@ -12,11 +12,15 @@ reported;Pulverturm Herrenberg, Herrenberg;8.86487934;48.5964194;;;Herrenberg;48
 reported;Schlossbergturm Herrenberg, Herrenberg;8.86487934;48.5964194;;;Herrenberg;48.59752855,8.873141062390543,800;de;
 reported;Herrenberger Straße, Herrenberg;8.86487934;48.5964194;;;Nufringen;48.614423,8.8814198,800;de;
 reported;Stuttgart hauptbahnhof, Stuttgart;8.86487934;48.5964194;;;Stuttgart;48.7856099,9.1833959,800;de;
-reported;Böblingen Bahnhof, Böblingen;8.86487934;48.5964194;;;Herrenberg;48.593861700000005,8.86307270000001,800;de;
+reported;Böblingen Bahnhof, Böblingen;8.86487934;48.5964194;;;Böblingen;48.688044,9.0047319,800;de;
 reported;E-bikes station, Herrenberg Bahnhof;8.86487934;48.5964194;;;Vaihingen an der Enz;48.947360950000004,8.957937857930657,800;de;
 reported;VHS;8.86487934;48.5964194;;;Herrenberg;48.5940213,8.8735124,800;de;
 reported;Stadtarchiv;8.86487934;48.5964194;;;Herrenberg;48.592641,8.87408,800;de;
 reported;Stadtbibliothek;8.86487934;48.5964194;;;Mötzingen;48.533602,8.7748135,800;de;
 reported (synonyms);Krankenhaus Herrenberg;8.86487934;48.5964194;;;Herrenberg;48.5920188,8.8769826,800;de;
 reported (synonyms);Klinikum Herrenberg;8.86487934;48.5964194;;;Herrenberg;48.5920188,8.8769826,800;de;
-
+reported (synonyms);Polizeischule;8.86487934;48.5964194;;;Herrenberg;48.60975,8.87967,800;de;
+reported (synonyms);Polizeihochschule;8.86487934;48.5964194;;;Herrenberg;48.60975,8.87967,800;de;
+reported (location bias focus Tübingen);Herrenberg;9.0535531;48.5236164;;;Herrenberg;48.595557,8.8674715,800;de;
+reported (location bias focus Tübingen);Herrenberg;9.0535531;48.5236164;;;Herrenberg;48.595557,8.8674715,800;de;
+reported (location bias focus Böblingen);Herrenberg;9.0047319;48.688044;;;Herrenberg;48.595557,8.8674715,800;de;

--- a/geocoder_tester/world/germany/herrenberg/test_house_numbers_herrenberg.csv
+++ b/geocoder_tester/world/germany/herrenberg/test_house_numbers_herrenberg.csv
@@ -5,17 +5,15 @@ house;15 Daimlerstraße Herrenberg (Stadt);48.603564, 8.870127914868021, 800;15;
 house;8 Römerstraße Altingen;48.5610945, 8.9096851, 800;8;Ammerbuch;72119;Deutschland;de
 house;97 Hohenzollernstraße Haslach;48.58427105, 8.833404192808445, 800;97;Herrenberg;71083;Deutschland;de
 house;15 Rigipsstraße Gültstein;48.5770198, 8.8843481, 800;15;Herrenberg;71083;Deutschland;de
-house;88 Grabenstraße Rohrau;48.6368092, 8.895110222721602, 800;88;Gärtringen;71116;Deutschland;de
 house;8 Längenholz Herrenberg (Stadt);48.58769075, 8.875360583505701, 800;8;Herrenberg;71083;Deutschland;de
 house;52 Schwedenstraße Altingen;48.5578992, 8.906734761828854, 800;52;Ammerbuch;72119;Deutschland;de
 house;10 Keltenstraße Kuppingen;48.61545845, 8.840431060932307, 800;10;Herrenberg;71083;Deutschland;de
 house;90 Gänsbergring Gültstein;48.5758156, 8.8763321, 800;90;Herrenberg;71083;Deutschland;de
 house;1 Jettinger Straße Öschelbronn;48.5525316, 8.8249698, 800;1;Gäufelden;71126;Deutschland;de
 house;112 Beim Bahnhof Breitenholz;48.5606608, 8.949487148792613, 800;112;Ammerbuch;72119;Deutschland;de
-house;58 Altinger Straße Gültstein;48.572387750000004, 8.88340202968183, 800;58;Gültstein;71083;Deutschland;de
+house;58 Altinger Straße Gültstein;48.572387750000004, 8.88340202968183, 800;58;Herrenberg;71083;Deutschland;de
 house;77 Rheinstraße Oberjesingen;48.6219411, 8.828216634952634, 800;77;Herrenberg;71083;Deutschland;de
 house;1 Karpatenstraße Gültstein;48.5781695, 8.878171688362979, 800;1;Herrenberg;71083;Deutschland;de
-house;58 Altinger Straße Gültstein;48.572387750000004, 8.88340202968183, 800;58;Gültstein;71083;Deutschland;de
 house;9 Schießmauer Herrenberg (Stadt);48.5987976, 8.861898897476461, 800;9;Herrenberg;71083;Deutschland;de
 house;11 Hertzstraße Gültstein;48.576429899999994, 8.896956395867452, 800;11;Herrenberg;71083;Deutschland;de
 house;16 Siedlerstraße Nebringen;48.560198, 8.8548402, 800;16;Gäufelden;71126;Deutschland;de
@@ -59,7 +57,7 @@ house;55 Zeppelinstraße Entringen;48.556591, 8.960630015970818, 800;55;Ammerbuc
 house;1 Amselweg Herrenberg (Stadt);48.5899154, 8.8614046, 800;1;Herrenberg;71083;Deutschland;de
 house;11 Keltenstraße Kuppingen;48.6147889, 8.837963503564453, 800;11;Herrenberg;71083;Deutschland;de
 house;10 Schloßstraße Sindlingen;48.5693577, 8.810145043523757, 800;10;Jettingen;71131;Deutschland;de
-house;88 Grabenstraße Rohrau;48.6368092, 8.895110222721602, 800;88;Gärtringen;71116;Deutschland;de
+house;88 Grabenstraße Gärtringen;48.6368092, 8.895110222721602, 800;88;Gärtringen;71116;Deutschland;de
 house;1 Weildorf Nebringen;48.556067, 8.84065476401743, 800;1;Gäufelden;71126;Deutschland;de
 house;2 Hewlett-Packard-Straße Gültstein;48.5822537, 8.8926361, 800;2;Herrenberg;71083;Deutschland;de
 house;15 Robert-Bosch-Straße Rohrau;48.6363835, 8.909133886283307, 800;15;Gärtringen;71116;Deutschland;de
@@ -77,7 +75,7 @@ house;33 Hohenzollernstraße Haslach;48.5829538, 8.8397126, 800;33;Herrenberg;71
 house;11 Keltenstraße Kuppingen;48.6147889, 8.837963503564453, 800;11;Herrenberg;71083;Deutschland;de
 house;1 Weildorf Nebringen;48.556067, 8.84065476401743, 800;1;Gäufelden;71126;Deutschland;de
 house;97 Hohenzollernstraße Haslach;48.5843935, 8.8336527, 800;97;Herrenberg;71083;Deutschland;de
-house;18 Rheinstraße Oberjesingen;48.622630099999995, 8.828886827089338, 800;18;Oberjesingen;71083;Deutschland;de
+house;18 Rheinstraße Oberjesingen;48.622630099999995, 8.828886827089338, 800;18;Herrenberg;71083;Deutschland;de
 house;15 Hertzstraße Gültstein;48.5753877, 8.8962805, 800;15;Herrenberg;71083;Deutschland;de
 house;3 Hewlett-Packard-Straße Gültstein;48.5819282, 8.889666600428846, 800;3;Herrenberg;71083;Deutschland;de
 house;33 Schießtäle Herrenberg (Stadt);48.592182199999996, 8.854641069408544, 800;33;Herrenberg;71083;Deutschland;de

--- a/geocoder_tester/world/germany/herrenberg/test_house_numbers_herrenberg.csv
+++ b/geocoder_tester/world/germany/herrenberg/test_house_numbers_herrenberg.csv
@@ -1,0 +1,96 @@
+comment;query;expected_coordinate;expected_housenumber;expected_city;expected_postcode;expected_country;lang
+house;25/2 Benzstraße Herrenberg (Stadt);48.6018337, 8.867583795945528, 800;25/2;Herrenberg;71083;Deutschland;de
+house;48 Schwedenstraße Altingen;48.557574, 8.9062707, 800;48;Ammerbuch;72119;Deutschland;de
+house;15 Daimlerstraße Herrenberg (Stadt);48.603564, 8.870127914868021, 800;15;Herrenberg;71083;Deutschland;de
+house;8 Römerstraße Altingen;48.5610945, 8.9096851, 800;8;Ammerbuch;72119;Deutschland;de
+house;97 Hohenzollernstraße Haslach;48.58427105, 8.833404192808445, 800;97;Herrenberg;71083;Deutschland;de
+house;15 Rigipsstraße Gültstein;48.5770198, 8.8843481, 800;15;Herrenberg;71083;Deutschland;de
+house;88 Grabenstraße Rohrau;48.6368092, 8.895110222721602, 800;88;Gärtringen;71116;Deutschland;de
+house;8 Längenholz Herrenberg (Stadt);48.58769075, 8.875360583505701, 800;8;Herrenberg;71083;Deutschland;de
+house;52 Schwedenstraße Altingen;48.5578992, 8.906734761828854, 800;52;Ammerbuch;72119;Deutschland;de
+house;10 Keltenstraße Kuppingen;48.61545845, 8.840431060932307, 800;10;Herrenberg;71083;Deutschland;de
+house;90 Gänsbergring Gültstein;48.5758156, 8.8763321, 800;90;Herrenberg;71083;Deutschland;de
+house;1 Jettinger Straße Öschelbronn;48.5525316, 8.8249698, 800;1;Gäufelden;71126;Deutschland;de
+house;112 Beim Bahnhof Breitenholz;48.5606608, 8.949487148792613, 800;112;Ammerbuch;72119;Deutschland;de
+house;58 Altinger Straße Gültstein;48.572387750000004, 8.88340202968183, 800;58;Gültstein;71083;Deutschland;de
+house;77 Rheinstraße Oberjesingen;48.6219411, 8.828216634952634, 800;77;Herrenberg;71083;Deutschland;de
+house;1 Karpatenstraße Gültstein;48.5781695, 8.878171688362979, 800;1;Herrenberg;71083;Deutschland;de
+house;58 Altinger Straße Gültstein;48.572387750000004, 8.88340202968183, 800;58;Gültstein;71083;Deutschland;de
+house;9 Schießmauer Herrenberg (Stadt);48.5987976, 8.861898897476461, 800;9;Herrenberg;71083;Deutschland;de
+house;11 Hertzstraße Gültstein;48.576429899999994, 8.896956395867452, 800;11;Herrenberg;71083;Deutschland;de
+house;16 Siedlerstraße Nebringen;48.560198, 8.8548402, 800;16;Gäufelden;71126;Deutschland;de
+house;15 Daimlerstraße Herrenberg (Stadt);48.603564, 8.870127914868021, 800;15;Herrenberg;71083;Deutschland;de
+house;4 Eichenstraße Nebringen;48.5656945, 8.849198008629108, 800;4;Gäufelden;71126;Deutschland;de
+house;6 Siemensstraße Rohrau;48.63649495, 8.91129075, 800;6;Gärtringen;71116;Deutschland;de
+house;80 Sindlinger Straße Nebringen;48.5668941, 8.827914533956527, 800;80;Gäufelden;71126;Deutschland;de
+house;14 Sandweg Altingen;48.56870715, 8.914892064681915, 800;14;Ammerbuch;72119;Deutschland;de
+house;2 Heerstraße Gültstein;48.5776084, 8.8896915, 800;2;Herrenberg;71083;Deutschland;de
+house;18 Silcherstraße Herrenberg (Stadt);48.5909534, 8.8641507, 800;18;Herrenberg;71083;Deutschland;de
+house;41 Hartstraße Altingen;48.55908915, 8.916255515004433, 800;41;Ammerbuch;72119;Deutschland;de
+house;3 Hertzstraße Gültstein;48.576921999999996, 8.891054554710273, 800;3;Herrenberg;71083;Deutschland;de
+house;43 Oberjesinger Straße Kuppingen;48.612941, 8.842352, 800;43;Herrenberg;71083;Deutschland;de
+house;100 Hofstattstraße Rohrau;48.62143795, 8.924668481239319, 800;100;Gärtringen;71116;Deutschland;de
+house;30 Moselstraße Oberjesingen;48.6200782, 8.8275682, 800;30;Herrenberg;71083;Deutschland;de
+house;11 Keltenstraße Kuppingen;48.6147889, 8.837963503564453, 800;11;Herrenberg;71083;Deutschland;de
+house;18/1 Schießtäle Herrenberg (Stadt);48.5945827, 8.8579752, 800;18/1;Herrenberg;71083;Deutschland;de
+house;1 Industriestraße Rohrau;48.629880799999995, 8.92497220234463, 800;1;Gärtringen;71116;Deutschland;de
+house;4 Zeppelinstraße Herrenberg (Stadt);48.600218299999995, 8.86533786246662, 800;4;Herrenberg;71083;Deutschland;de
+house;20 Schollerstraße Nebringen;48.5562568, 8.842508717664906, 800;20;Gäufelden;71126;Deutschland;de
+house;48 Siedlerstraße Nebringen;48.5602268, 8.858652, 800;48;Gäufelden;71126;Deutschland;de
+house;43 In den Böden Nebringen;48.5554741, 8.8537098, 800;43;Gäufelden;71126;Deutschland;de
+house;1 Raiffeisenstraße Nebringen;48.5589873, 8.8524815, 800;1;Gäufelden;71126;Deutschland;de
+house;80 Sindlinger Straße Nebringen;48.5668941, 8.827914533956527, 800;80;Gäufelden;71126;Deutschland;de
+house;1 Weildorf Nebringen;48.556067, 8.84065476401743, 800;1;Gäufelden;71126;Deutschland;de
+house;70 Kappstraße Gültstein;48.57567365, 8.88946430060014, 800;70;Herrenberg;71083;Deutschland;de
+house;17 Sindlinger Straße Nebringen;48.5628535, 8.8470075, 800;17;Gäufelden;71126;Deutschland;de
+house;2 Hertzstraße Gültstein;48.575432649999996, 8.891549268767587, 800;2;Herrenberg;71083;Deutschland;de
+house;62b Grabenstraße Rohrau;48.6370743, 8.8974124, 800;62b;Gärtringen;71116;Deutschland;de
+house;9 Wiesenstraße Altingen;48.562458649999996, 8.903874268897845, 800;9;Ammerbuch;72119;Deutschland;de
+house;54 Müneckstraße Breitenholz;48.5712441, 8.962516902079006, 800;54;Ammerbuch;72119;Deutschland;de
+house;11 Jahnstraße Öschelbronn;48.5515118, 8.820945104848768, 800;11;Gäufelden;71126;Deutschland;de
+house;2 Waldstraße Nebringen;48.56475665, 8.847273049999998, 800;2;Gäufelden;71126;Deutschland;de
+house;12 Marie-Curie-Straße Gültstein;48.5745725, 8.8961912, 800;12;Herrenberg;71083;Deutschland;de
+locality;16 Plapphalde Haslach;48.5870195, 8.843098637403852, 800;16;Herrenberg;71083;Deutschland;de
+house;20 Schollerstraße Nebringen;48.5562568, 8.842508717664906, 800;20;Gäufelden;71126;Deutschland;de
+house;1 Weildorf Nebringen;48.556067, 8.84065476401743, 800;1;Gäufelden;71126;Deutschland;de
+house;1/1 Hewlett-Packard-Straße Gültstein;48.5807561, 8.8920086, 800;1/1;Herrenberg;71083;Deutschland;de
+house;16 Siedlerstraße Nebringen;48.560198, 8.8548402, 800;16;Gäufelden;71126;Deutschland;de
+house;55 Zeppelinstraße Entringen;48.556591, 8.960630015970818, 800;55;Ammerbuch;72119;Deutschland;de
+house;1 Amselweg Herrenberg (Stadt);48.5899154, 8.8614046, 800;1;Herrenberg;71083;Deutschland;de
+house;11 Keltenstraße Kuppingen;48.6147889, 8.837963503564453, 800;11;Herrenberg;71083;Deutschland;de
+house;10 Schloßstraße Sindlingen;48.5693577, 8.810145043523757, 800;10;Jettingen;71131;Deutschland;de
+house;88 Grabenstraße Rohrau;48.6368092, 8.895110222721602, 800;88;Gärtringen;71116;Deutschland;de
+house;1 Weildorf Nebringen;48.556067, 8.84065476401743, 800;1;Gäufelden;71126;Deutschland;de
+house;2 Hewlett-Packard-Straße Gültstein;48.5822537, 8.8926361, 800;2;Herrenberg;71083;Deutschland;de
+house;15 Robert-Bosch-Straße Rohrau;48.6363835, 8.909133886283307, 800;15;Gärtringen;71116;Deutschland;de
+house;3 Berliner Straße Herrenberg (Stadt);48.59385385, 8.856316476936918, 800;3;Herrenberg;71083;Deutschland;de
+house;62a Grabenstraße Rohrau;48.6368193, 8.8978222, 800;62a;Gärtringen;71116;Deutschland;de
+house;19 Gipswerkstraße Kayh;48.57300015, 8.915534634782484, 800;19;Herrenberg;71083;Deutschland;de
+house;9 Grabenstraße Rohrau;48.6375181, 8.9034252, 800;9;Gärtringen;71116;Deutschland;de
+house;6 Schießmauer Herrenberg (Stadt);48.5971897, 8.863687868204037, 800;6;Herrenberg;71083;Deutschland;de
+house;19 Hagenring Altingen;48.5658702, 8.905024537789405, 800;19;Ammerbuch;72119;Deutschland;de
+house;6 Zeppelinstraße Herrenberg (Stadt);48.6000858, 8.864645571687522, 800;6;Herrenberg;71083;Deutschland;de
+house;57 Römerweg Kuppingen;48.61140915, 8.851078095049678, 800;57;Herrenberg;71083;Deutschland;de
+house;2 Eisenbahnstraße Nebringen;48.5599048, 8.8480275, 800;2;Gäufelden;71126;Deutschland;de
+house;10 Schloßstraße Sindlingen;48.5693577, 8.810145043523757, 800;10;Jettingen;71131;Deutschland;de
+house;33 Hohenzollernstraße Haslach;48.5829538, 8.8397126, 800;33;Herrenberg;71083;Deutschland;de
+house;11 Keltenstraße Kuppingen;48.6147889, 8.837963503564453, 800;11;Herrenberg;71083;Deutschland;de
+house;1 Weildorf Nebringen;48.556067, 8.84065476401743, 800;1;Gäufelden;71126;Deutschland;de
+house;97 Hohenzollernstraße Haslach;48.5843935, 8.8336527, 800;97;Herrenberg;71083;Deutschland;de
+house;18 Rheinstraße Oberjesingen;48.622630099999995, 8.828886827089338, 800;18;Oberjesingen;71083;Deutschland;de
+house;15 Hertzstraße Gültstein;48.5753877, 8.8962805, 800;15;Herrenberg;71083;Deutschland;de
+house;3 Hewlett-Packard-Straße Gültstein;48.5819282, 8.889666600428846, 800;3;Herrenberg;71083;Deutschland;de
+house;33 Schießtäle Herrenberg (Stadt);48.592182199999996, 8.854641069408544, 800;33;Herrenberg;71083;Deutschland;de
+house;9 Wiesenstraße Altingen;48.562458649999996, 8.903874268897845, 800;9;Ammerbuch;72119;Deutschland;de
+house;1 Jettinger Straße Öschelbronn;48.5525316, 8.8249698, 800;1;Gäufelden;71126;Deutschland;de
+locality;16 Plapphalde Haslach;48.5870195, 8.843098637403852, 800;16;Herrenberg;71083;Deutschland;de
+house;2 Marie-Curie-Straße Gültstein;48.5746778, 8.8941479, 800;2;Herrenberg;71083;Deutschland;de
+house;13 Würmstraße Oberjesingen;48.622959249999994, 8.838719752631494, 800;13;Herrenberg;71083;Deutschland;de
+house;11 Keltenstraße Kuppingen;48.6147889, 8.837963503564453, 800;11;Herrenberg;71083;Deutschland;de
+house;4 Im Pfarrgäßle Oberjesingen;48.625681099999994, 8.836575427842961, 800;4;Herrenberg;71083;Deutschland;de
+house;19 Rosenstraße Altingen;48.5615517, 8.9064545, 800;19;Ammerbuch;72119;Deutschland;de
+house;2 Heerstraße Gültstein;48.5776186, 8.8888686, 800;2;Herrenberg;71083;Deutschland;de
+house;2 Unter dem Aischbächle Sägmühle;48.5696485, 8.8894308, 800;2;Herrenberg;71083;Deutschland;de
+house;2 Jahnweg Herrenberg (Stadt);48.59918515, 8.867285946731734, 800;2;Herrenberg;71083;Deutschland;de
+house;6 Bei der Schießmauer Entringen;48.5574596, 8.9602102, 800;6;Ammerbuch;72119;Deutschland;de
+house;100 Hofstattstraße Gärtringen-Rohrau;48.6215997, 8.9249399, 800;100;Gärtringen;71116;Deutschland;de

--- a/geocoder_tester/world/germany/herrenberg/test_house_numbers_herrenberg.csv
+++ b/geocoder_tester/world/germany/herrenberg/test_house_numbers_herrenberg.csv
@@ -64,7 +64,7 @@ house;15 Robert-Bosch-Straße Rohrau;48.6363835, 8.909133886283307, 800;15;Gärt
 house;3 Berliner Straße Herrenberg (Stadt);48.59385385, 8.856316476936918, 800;3;Herrenberg;71083;Deutschland;de
 house;62a Grabenstraße Rohrau;48.6368193, 8.8978222, 800;62a;Gärtringen;71116;Deutschland;de
 house;19 Gipswerkstraße Kayh;48.57300015, 8.915534634782484, 800;19;Herrenberg;71083;Deutschland;de
-house;9 Grabenstraße Rohrau;48.6375181, 8.9034252, 800;9;Gärtringen;71116;Deutschland;de
+house;9 Grabenstraße Gärtringen;48.6375181, 8.9034252, 800;9;Gärtringen;71116;Deutschland;de
 house;6 Schießmauer Herrenberg (Stadt);48.5971897, 8.863687868204037, 800;6;Herrenberg;71083;Deutschland;de
 house;19 Hagenring Altingen;48.5658702, 8.905024537789405, 800;19;Ammerbuch;72119;Deutschland;de
 house;6 Zeppelinstraße Herrenberg (Stadt);48.6000858, 8.864645571687522, 800;6;Herrenberg;71083;Deutschland;de

--- a/geocoder_tester/world/germany/herrenberg/test_random_addresses.csv
+++ b/geocoder_tester/world/germany/herrenberg/test_random_addresses.csv
@@ -1,0 +1,101 @@
+comment;query;lon;lat;expected_coordinate;expected_name;expected_country;lang
+street;In der Ebene;8.86487934;48.5964194;48.5065659, 8.9455469, 800;;Deutschland;de
+street;Wasserbaumweg;8.86487934;48.5964194;48.6634601, 8.8325198, 800;;Deutschland;de
+street;Tailfinger Straße;8.86487934;48.5964194;48.5504842, 8.8357702, 800;;Deutschland;de
+house;Sindlinger Hof;8.86487934;48.5964194;48.5713229, 8.810577550000003, 800;;Deutschland;de
+street;Hohlweg;8.86487934;48.5964194;48.5751156, 8.9497058, 800;;Deutschland;de
+house;Gewächshaus;8.86487934;48.5964194;48.5716319, 8.856454368993994, 800;;Deutschland;de
+house;Stockenwald;8.86487934;48.5964194;48.6908379, 8.8616852, 800;;Deutschland;de
+street;Mittlerer Weg;8.86487934;48.5964194;48.5484355, 8.9636757, 800;;Deutschland;de
+house;Sonnenzentrum - Hartmann Energietechnik GmbH;8.86487934;48.5964194;48.5237147, 8.9206068, 800;;Deutschland;de
+house;Gasthof Mammel;8.86487934;48.5964194;48.69784725, 8.939567397908895, 800;;Deutschland;de
+street;Horber Straße;8.86487934;48.5964194;48.5874488, 8.8647968, 800;;Deutschland;de
+house;Würmhalde;8.86487934;48.5964194;48.6997787, 8.8997684, 800;;Deutschland;de
+house;Das Sühnekreuz;8.86487934;48.5964194;48.5066985, 8.9592469, 800;;Deutschland;de
+house;Hummelbergweg;8.86487934;48.5964194;48.6753291, 8.8422212, 800;;Deutschland;de
+street;Dreispitzallee;8.86487934;48.5964194;48.663761, 8.8907935, 800;;Deutschland;de
+house;Wasserhäuschen;8.86487934;48.5964194;48.62133645, 8.823316881606765, 800;;Deutschland;de
+street;Eichenstraße;8.86487934;48.5964194;48.5661422, 8.8473453, 800;;Deutschland;de
+house;Softwarezentrum Böblingen/Sindelfingen;8.86487934;48.5964194;48.681021799999996, 8.973981841901603, 800;;Deutschland;de
+house;Augenzentrum Eckert: Herrenberg Augenarzt;8.86487934;48.5964194;48.5926625, 8.8609589, 800;;Deutschland;de
+street;Herdweg;8.86487934;48.5964194;48.5557482, 8.8090037, 800;;Deutschland;de
+house;Pfäffingen;8.86487934;48.5964194;48.5322275, 8.9645553, 800;;Deutschland;de
+street;Glockenrainweg;8.86487934;48.5964194;48.5880366, 8.9437032, 800;;Deutschland;de
+street;Calwer Straße;8.86487934;48.5964194;48.6803613, 8.855251, 800;;Deutschland;de
+street;Raichbergstraße;8.86487934;48.5964194;48.5035023, 8.8734468, 800;;Deutschland;de
+house;Auto Bebion;8.86487934;48.5964194;48.600218299999995, 8.86533786246662, 800;;Deutschland;de
+street;Talsträßchen;8.86487934;48.5964194;48.5909415, 8.7952088, 800;;Deutschland;de
+locality;SAUTTER & STEPPER GmbH;8.86487934;48.5964194;48.557106950000005, 8.91708752099845, 800;;Deutschland;de
+street;Traubenstraße;8.86487934;48.5964194;48.5780921, 8.9170195, 800;;Deutschland;de
+street;Feldzaunweg;8.86487934;48.5964194;48.5493019, 8.8715136, 800;;Deutschland;de
+street;Lembergstraße;8.86487934;48.5964194;48.5780994, 8.8346985, 800;;Deutschland;de
+house;Fischer-Hütte;8.86487934;48.5964194;48.5885656, 8.9350448, 800;;Deutschland;de
+house;Kirchweg;8.86487934;48.5964194;48.6861592, 8.8985261, 800;;Deutschland;de
+street;Haldenweg;8.86487934;48.5964194;48.6856431, 8.8949292, 800;;Deutschland;de
+street;Holunderstraße;8.86487934;48.5964194;48.5762988, 8.8737027, 800;;Deutschland;de
+street;Kayher Talsträßle;8.86487934;48.5964194;48.5898575, 8.9297378, 800;;Deutschland;de
+street;Pirolstraße;8.86487934;48.5964194;48.5050943, 8.9330402, 800;;Deutschland;de
+house;Boltzplatz mit Toren;8.86487934;48.5964194;48.681403450000005, 8.872873396004316, 800;;Deutschland;de
+locality;Öfele;8.86487934;48.5964194;48.5788466, 8.8012738, 800;;Deutschland;de
+street;Albert-Schweitzer-Straße;8.86487934;48.5964194;48.697504, 8.9644106, 800;;Deutschland;de
+house;Härenslochweg Süd;8.86487934;48.5964194;48.5670693, 8.9712244, 800;;Deutschland;de
+street;Wurmlinger Straße;8.86487934;48.5964194;48.5212693, 8.9643967, 800;;Deutschland;de
+street;Deckenpfronner Weg;8.86487934;48.5964194;48.6225136, 8.7802223, 800;;Deutschland;de
+street;Deufringer Weg;8.86487934;48.5964194;48.6646418, 8.8969747, 800;;Deutschland;de
+house;Adlerspielplatz;8.86487934;48.5964194;48.5046502, 8.935209727967397, 800;;Deutschland;de
+house;Forstknechtstein;8.86487934;48.5964194;48.6061451, 8.7978969, 800;;Deutschland;de
+locality;Wengerthof;8.86487934;48.5964194;48.5584814, 8.866047641571384, 800;;Deutschland;de
+house;Altinger Jägerlinde;8.86487934;48.5964194;48.5595892, 8.9337739, 800;;Deutschland;de
+street;Talrainweg;8.86487934;48.5964194;48.5887788, 8.9371461, 800;;Deutschland;de
+street;Gültsteiner Straße;8.86487934;48.5964194;48.5595814, 8.8799246, 800;;Deutschland;de
+house;Asch;8.86487934;48.5964194;48.56496625, 8.908561495824225, 800;;Deutschland;de
+street;Feldweg 614;8.86487934;48.5964194;48.5266298, 8.9018597, 800;;Deutschland;de
+street;Altenhausgasse;8.86487934;48.5964194;48.6260007, 8.8379801, 800;;Deutschland;de
+street;Herdweg;8.86487934;48.5964194;48.5557482, 8.8090037, 800;;Deutschland;de
+street;Talstraße;8.86487934;48.5964194;48.6816756, 8.9073539, 800;;Deutschland;de
+street;Grünplattweg;8.86487934;48.5964194;48.6818833, 8.7900811, 800;;Deutschland;de
+house;Mischwald;8.86487934;48.5964194;48.5926866, 8.8218804, 800;;Deutschland;de
+street;Bollstraße;8.86487934;48.5964194;48.525057, 8.9154253, 800;;Deutschland;de
+street;Neckarstraße;8.86487934;48.5964194;48.6175517, 8.8401364, 800;;Deutschland;de
+house;ASV Pfäffingen;8.86487934;48.5964194;48.5282138, 8.9609323, 800;;Deutschland;de
+street;Bahndammtunnel;8.86487934;48.5964194;48.5775477, 8.8565849, 800;;Deutschland;de
+house;Peter-Schanz-Stein;8.86487934;48.5964194;48.5938332, 8.9151425, 800;;Deutschland;de
+street;Döffinger Straße;8.86487934;48.5964194;48.6991397, 8.9486507, 800;;Deutschland;de
+street;Wilhelm-Busch-Straße;8.86487934;48.5964194;48.6918385, 8.9560005, 800;;Deutschland;de
+house;Aussiedlerhöfe;8.86487934;48.5964194;48.5910044, 8.8292002, 800;;Deutschland;de
+street;Ehninger Weg;8.86487934;48.5964194;48.685708, 8.9455264, 800;;Deutschland;de
+street;Mühlstraße;8.86487934;48.5964194;48.6022952, 8.8604627, 800;;Deutschland;de
+street;Öfelepass;8.86487934;48.5964194;48.5770421, 8.8077616, 800;;Deutschland;de
+street;Am Stich;8.86487934;48.5964194;48.5641866, 8.840916, 800;;Deutschland;de
+street;Unterer Katermannshaldeweg;8.86487934;48.5964194;48.5848632, 8.971072, 800;;Deutschland;de
+street;Bussteig C;8.86487934;48.5964194;48.5944062, 8.864552, 800;;Deutschland;de
+locality;Brenner Hof;8.86487934;48.5964194;48.60562315, 8.832245933335313, 800;;Deutschland;de
+house;Streuobst macht Arbeit;8.86487934;48.5964194;48.5838545, 8.9053579, 800;;Deutschland;de
+street;Peter Schanz Weg;8.86487934;48.5964194;48.5885961, 8.9171949, 800;;Deutschland;de
+street;Stuttgarter Straße;8.86487934;48.5964194;48.555509, 8.8335483, 800;;Deutschland;de
+house;Nubenhäusle;8.86487934;48.5964194;48.570057399999996, 8.967834650000004, 800;;Deutschland;de
+locality;Besemer;8.86487934;48.5964194;48.6929699, 8.842071, 800;;Deutschland;de
+street;Wielandstraße;8.86487934;48.5964194;48.561578, 8.782557, 800;;Deutschland;de
+street;Saatschulweg;8.86487934;48.5964194;48.687868, 8.8501383, 800;;Deutschland;de
+house;Oberndorfer Linde;8.86487934;48.5964194;48.5214317, 8.9256204, 800;;Deutschland;de
+house;Vera's Backstüble;8.86487934;48.5964194;48.6931748, 8.96123, 800;;Deutschland;de
+street;Jauenweg;8.86487934;48.5964194;48.5287241, 8.9271445, 800;;Deutschland;de
+house;Gas-Druckregelanlage Altingen;8.86487934;48.5964194;48.55866695, 8.92459108097015, 800;;Deutschland;de
+house;Insektenhotel;8.86487934;48.5964194;48.6860675, 8.9259532, 800;;Deutschland;de
+house;Kochhartgraben und Ammertalhänge;8.86487934;48.5964194;48.54049555, 8.904950544036954, 800;;Deutschland;de
+street;Bodenseeautobahn;8.86487934;48.5964194;48.5463236, 8.8893049, 800;;Deutschland;de
+street;Alzentalstraße;8.86487934;48.5964194;48.5917148, 8.8669559, 800;;Deutschland;de
+street;Feldweg 614;8.86487934;48.5964194;48.5266298, 8.9018597, 800;;Deutschland;de
+street;Elbenstraße;8.86487934;48.5964194;48.6215998, 8.8346018, 800;;Deutschland;de
+street;Brandplattenweg;8.86487934;48.5964194;48.5836145, 8.9743254, 800;;Deutschland;de
+street;Hinterhagstraße;8.86487934;48.5964194;48.6773938, 8.8948598, 800;;Deutschland;de
+street;Drosselweg;8.86487934;48.5964194;48.56295, 8.7910703, 800;;Deutschland;de
+street;Sontheimer Straße;8.86487934;48.5964194;48.5111916, 8.8736518, 800;;Deutschland;de
+street;Tannenweg;8.86487934;48.5964194;48.6225803, 8.8051221, 800;;Deutschland;de
+street;Roseckstraße;8.86487934;48.5964194;48.5078853, 8.8866144, 800;;Deutschland;de
+house;Schloß Sindlingen;8.86487934;48.5964194;48.5693577, 8.810145043523757, 800;;Deutschland;de
+street;Bodenseeautobahn;8.86487934;48.5964194;48.5937907, 8.8967988, 800;;Deutschland;de
+house;Kaiser;8.86487934;48.5964194;48.51989445, 8.967526305071354, 800;;Deutschland;de
+street;Im Eichenpfädle;8.86487934;48.5964194;48.6963361, 8.9571495, 800;;Deutschland;de
+street;Heubergring;8.86487934;48.5964194;48.5702334, 8.785224, 800;;Deutschland;de
+street;Hohleweg;8.86487934;48.5964194;48.5966637, 8.7974958, 800;;Deutschland;de

--- a/geocoder_tester/world/germany/herrenberg/test_random_addresses.csv
+++ b/geocoder_tester/world/germany/herrenberg/test_random_addresses.csv
@@ -33,11 +33,11 @@ house;Fischer-Hütte;8.86487934;48.5964194;48.5885656, 8.9350448, 800;;Deutschla
 house;Kirchweg;8.86487934;48.5964194;48.6861592, 8.8985261, 800;;Deutschland;de
 street;Haldenweg;8.86487934;48.5964194;48.6856431, 8.8949292, 800;;Deutschland;de
 street;Holunderstraße;8.86487934;48.5964194;48.5762988, 8.8737027, 800;;Deutschland;de
-street;Kayher Talsträßle;8.86487934;48.5964194;48.5898575, 8.9297378, 800;;Deutschland;de
+forrest path;Kayher Talsträßle;8.86487934;48.5964194;48.5898575, 8.9297378, 2000;;Deutschland;de
 street;Pirolstraße;8.86487934;48.5964194;48.5050943, 8.9330402, 800;;Deutschland;de
 house;Boltzplatz mit Toren;8.86487934;48.5964194;48.681403450000005, 8.872873396004316, 800;;Deutschland;de
 locality;Öfele;8.86487934;48.5964194;48.5788466, 8.8012738, 800;;Deutschland;de
-street;Albert-Schweitzer-Straße;8.86487934;48.5964194;48.697504, 8.9644106, 800;;Deutschland;de
+long street;Albert-Schweitzer-Straße;8.86487934;48.5964194;48.697504, 8.9644106, 1000;;Deutschland;de
 house;Härenslochweg Süd;8.86487934;48.5964194;48.5670693, 8.9712244, 800;;Deutschland;de
 street;Wurmlinger Straße;8.86487934;48.5964194;48.5212693, 8.9643967, 800;;Deutschland;de
 street;Deckenpfronner Weg;8.86487934;48.5964194;48.6225136, 8.7802223, 800;;Deutschland;de

--- a/geocoder_tester/world/germany/herrenberg/test_random_addresses.csv
+++ b/geocoder_tester/world/germany/herrenberg/test_random_addresses.csv
@@ -49,10 +49,8 @@ house;Altinger Jägerlinde;8.86487934;48.5964194;48.5595892, 8.9337739, 800;;Deu
 street;Talrainweg;8.86487934;48.5964194;48.5887788, 8.9371461, 800;;Deutschland;de
 street;Gültsteiner Straße;8.86487934;48.5964194;48.5595814, 8.8799246, 800;;Deutschland;de
 house;Asch;8.86487934;48.5964194;48.56496625, 8.908561495824225, 800;;Deutschland;de
-street;Feldweg 614;8.86487934;48.5964194;48.5266298, 8.9018597, 800;;Deutschland;de
 street;Altenhausgasse;8.86487934;48.5964194;48.6260007, 8.8379801, 800;;Deutschland;de
 street;Herdweg;8.86487934;48.5964194;48.5557482, 8.8090037, 800;;Deutschland;de
-street;Talstraße;8.86487934;48.5964194;48.6816756, 8.9073539, 800;;Deutschland;de
 street;Grünplattweg;8.86487934;48.5964194;48.6818833, 8.7900811, 800;;Deutschland;de
 house;Mischwald;8.86487934;48.5964194;48.5926866, 8.8218804, 800;;Deutschland;de
 street;Bollstraße;8.86487934;48.5964194;48.525057, 8.9154253, 800;;Deutschland;de
@@ -83,9 +81,8 @@ street;Jauenweg;8.86487934;48.5964194;48.5287241, 8.9271445, 800;;Deutschland;de
 house;Gas-Druckregelanlage Altingen;8.86487934;48.5964194;48.55866695, 8.92459108097015, 800;;Deutschland;de
 house;Insektenhotel;8.86487934;48.5964194;48.6860675, 8.9259532, 800;;Deutschland;de
 house;Kochhartgraben und Ammertalhänge;8.86487934;48.5964194;48.54049555, 8.904950544036954, 800;;Deutschland;de
-street;Bodenseeautobahn;8.86487934;48.5964194;48.5463236, 8.8893049, 800;;Deutschland;de
+street (using reg_name);Bodenseeautobahn;8.86487934;48.5964194;48.5463236, 8.8893049, 800;;Deutschland;de
 street;Alzentalstraße;8.86487934;48.5964194;48.5917148, 8.8669559, 800;;Deutschland;de
-street;Feldweg 614;8.86487934;48.5964194;48.5266298, 8.9018597, 800;;Deutschland;de
 street;Elbenstraße;8.86487934;48.5964194;48.6215998, 8.8346018, 800;;Deutschland;de
 street;Brandplattenweg;8.86487934;48.5964194;48.5836145, 8.9743254, 800;;Deutschland;de
 street;Hinterhagstraße;8.86487934;48.5964194;48.6773938, 8.8948598, 800;;Deutschland;de
@@ -94,7 +91,6 @@ street;Sontheimer Straße;8.86487934;48.5964194;48.5111916, 8.8736518, 800;;Deut
 street;Tannenweg;8.86487934;48.5964194;48.6225803, 8.8051221, 800;;Deutschland;de
 street;Roseckstraße;8.86487934;48.5964194;48.5078853, 8.8866144, 800;;Deutschland;de
 house;Schloß Sindlingen;8.86487934;48.5964194;48.5693577, 8.810145043523757, 800;;Deutschland;de
-street;Bodenseeautobahn;8.86487934;48.5964194;48.5937907, 8.8967988, 800;;Deutschland;de
 house;Kaiser;8.86487934;48.5964194;48.51989445, 8.967526305071354, 800;;Deutschland;de
 street;Im Eichenpfädle;8.86487934;48.5964194;48.6963361, 8.9571495, 800;;Deutschland;de
 street;Heubergring;8.86487934;48.5964194;48.5702334, 8.785224, 800;;Deutschland;de

--- a/geocoder_tester/world/germany/herrenberg/test_stations_and_stops.csv
+++ b/geocoder_tester/world/germany/herrenberg/test_stations_and_stops.csv
@@ -1,0 +1,7 @@
+comment;query;lon;lat;expected_osm_value;expected_city;expected_coordinate;lang;limit
+Böblingen should return Böblingen Bahnhof;Böblingen;8.86487934;48.5964194;station;Böblingen;48.6880440, 9.0047319,500;de;3
+Stuttgart should return Stuttgart Hbf;Stuttgart;8.86487934;48.5964194;station;Stuttgart;48.7856099, 9.1833959,500;de;3
+Herrenberg should return Herrenberg Bahnhof;Herrenberg;8.86487934;48.5964194;station;Herrenberg;48.5940590, 8.8629217,500;de;3
+
+
+


### PR DESCRIPTION
- Add randomly generated address test cases for Herrenberg, Germany.
- Query for the name and add location bias for Herrenberg (lon, lat).